### PR TITLE
Add parsing credentials of python adapter from profiles.yml

### DIFF
--- a/core/dbt/config/runtime.py
+++ b/core/dbt/config/runtime.py
@@ -117,6 +117,7 @@ class RuntimeConfig(Project, Profile, AdapterRequiredConfig):
             user_config=profile.user_config,
             threads=profile.threads,
             credentials=profile.credentials,
+            python_adapter_credentials=profile.python_adapter_credentials,
             args=args,
             cli_vars=cli_vars,
             dependencies=dependencies,
@@ -402,6 +403,7 @@ class UnsetProfile(Profile):
         self.profile_name = ""
         self.target_name = ""
         self.threads = -1
+        self.python_adapter_credentials = UnsetCredentials()
 
     def to_target_dict(self):
         return DictDefaultEmptyStr({})
@@ -558,6 +560,7 @@ class UnsetProfileConfig(RuntimeConfig):
             args=args,
             cli_vars=cli_vars,
             dependencies=dependencies,
+            python_adapter_credentials=profile.python_adapter_credentials
         )
 
     @classmethod

--- a/core/dbt/contracts/project.py
+++ b/core/dbt/contracts/project.py
@@ -247,6 +247,7 @@ class ProfileConfig(HyphenatedDbtClassMixin, Replaceable):
     threads: int
     # TODO: make this a dynamic union of some kind?
     credentials: Optional[Dict[str, Any]]
+    python_adapter_credentials: Optional[Dict[str, Any]] = field(metadata={"preserve_underscore": True})
 
 
 @dataclass

--- a/core/dbt/task/debug.py
+++ b/core/dbt/task/debug.py
@@ -217,7 +217,7 @@ class DebugTask(BaseTask):
 
         renderer = ProfileRenderer(self.cli_vars)
 
-        target_name, _ = Profile.render_profile(
+        target_name, _, _ = Profile.render_profile(
             raw_profile=raw_profile,
             profile_name=profile_name,
             target_override=getattr(self.args, "target", None),


### PR DESCRIPTION
### Description

This PR enables parsing the property `python_adapter` for an adapter profile.

If we find the `python_adapter` property, it gets removed from the credentials before passing them to the adapter, so it does not "invade" its `Credentials` object.

It is backward compatible with the current parsing.

*****

We are changing the messages if an error happens while parsing the python adapter credentials.


Missing `type`
```
❯ dbt run
18:22:23  Encountered an error while reading profiles:
18:22:23    ERROR: Runtime Error
  required field "type" not found in profile jaffle_shop and target quack python adapter
18:22:23  Defined profiles:
18:22:23   - jaffle_shop
18:22:23
For more information on configuring profiles, please consult the dbt docs:

https://docs.getdbt.com/docs/configure-your-profile

18:22:23  Encountered an error:
Runtime Error
  Could not run dbt
```

Invalid fields
```
❯ dbt run
18:21:56  Encountered an error while reading profiles:
18:21:56    ERROR: Runtime Error
  Credentials in profile "jaffle_shop", target "quack" python adapter invalid: None is not of type 'string'
18:21:56  Defined profiles:
18:21:56   - jaffle_shop
18:21:56
For more information on configuring profiles, please consult the dbt docs:

https://docs.getdbt.com/docs/configure-your-profile

18:21:56  Encountered an error:
Runtime Error
  Could not run dbt
```