### PR TITLE
Call materialization from Python adapter for Python models

### DIFF
--- a/core/dbt/config/runtime.py
+++ b/core/dbt/config/runtime.py
@@ -321,6 +321,11 @@ class RuntimeConfig(Project, Profile, AdapterRequiredConfig):
         if self.dependencies is None:
             all_projects = {self.project_name: self}
             internal_packages = get_include_paths(self.credentials.type)
+            if self.python_adapter_credentials:
+                internal_packages += get_include_paths(self.python_adapter_credentials.type)
+                # remove any repeated project (global project)
+                internal_packages = list(set(internal_packages))
+
             if base_only:
                 # Test setup -- we want to load macros without dependencies
                 project_paths = itertools.chain(internal_packages)

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -691,18 +691,18 @@ class ProviderContext(ManifestContext):
         # mypy appeasement - we know it'll be a RuntimeConfig
         self.config: RuntimeConfig
         self.model: Union[ParsedMacro, ManifestNode] = model
+        self.adapter = get_adapter(config, getattr(model, 'language', 'sql'))
         super().__init__(config, manifest, model.package_name)
         self.sql_results: Dict[str, AttrDict] = {}
         self.context_config: Optional[ContextConfig] = context_config
         self.provider: Provider = provider
-        self.adapter = get_adapter(self.config)
         # The macro namespace is used in creating the DatabaseWrapper
         self.db_wrapper = self.provider.DatabaseWrapper(self.adapter, self.namespace)
 
     # This overrides the method in ManifestContext, and provides
     # a model, which the ManifestContext builder does not
     def _get_namespace_builder(self):
-        internal_packages = get_adapter_package_names(self.config.credentials.type)
+        internal_packages = get_adapter_package_names(self.adapter.type())
         return MacroNamespaceBuilder(
             self.config.project_name,
             self.search_package,

--- a/core/dbt/task/runnable.py
+++ b/core/dbt/task/runnable.py
@@ -188,7 +188,7 @@ class GraphRunnableTask(ManifestTask):
         return os.path.join(self.config.target_path, RESULT_FILE_NAME)
 
     def get_runner(self, node):
-        adapter = get_adapter(self.config)
+        adapter = get_adapter(self.config, getattr(node, 'language', 'sql'))
         run_count: int = 0
         num_nodes: int = 0
 


### PR DESCRIPTION
### Description

Load the python adapter packages (macros) too.

Get the correct adapter in the Jinja context (depends on the model's `language').

