### PR TITLE
act2: add base sync_teleport with hack for Python adapters

### DIFF
--- a/core/dbt/adapters/teleport/__init__.py
+++ b/core/dbt/adapters/teleport/__init__.py
@@ -1,0 +1,2 @@
+# these are all just exports, #noqa them so flake8 will be happy
+from dbt.adapters.teleport.impl import TeleportAdapter  # noqa

--- a/core/dbt/adapters/teleport/impl.py
+++ b/core/dbt/adapters/teleport/impl.py
@@ -1,0 +1,68 @@
+import abc
+from typing import List, Optional
+
+from dbt.exceptions import NotImplementedException
+from dbt.adapters.base import BaseRelation
+from dbt.teleport.teleport_info import TeleportInfo
+
+class TeleportAdapter:
+    """The TeleportAdapter provides an abstract class for adapters usable with Teleport.
+
+    Adapters must implement the following methods and macros. Some of the
+    methods can be safely overridden as a noop, where it makes sense. Those
+    methods are marked with a (passable) in their docstrings. Check docstrings
+    for type information, etc.
+
+    To implement a macro, implement "${adapter_type}__${macro_name}" in the
+    adapter's internal project.
+
+    To invoke a method in an adapter macro, call it on the 'adapter' Jinja
+    object using dot syntax.
+
+    To invoke a method in model code, add the @available decorator atop a method
+    declaration. Methods are invoked as macros.
+
+    Methods:
+        - storage_formats
+        # - teleport_backends
+        - teleport_from_external_storage
+        - teleport_to_external_storage
+
+    Macros:
+        -
+
+    """
+
+    wrapper: Optional["TeleportAdapter"]
+
+    @classmethod
+    @abc.abstractmethod
+    def storage_formats(cls) -> List[str]:
+        """
+        List of formats this adapter handles. e.g. `['csv', 'parquet']`
+        """
+        raise NotImplementedException(
+            "`storage_formats` is not implemented for this adapter!"
+        )
+
+    @abc.abstractmethod
+    def teleport_from_external_storage(
+        self, relation: BaseRelation, data_path: str, teleport_info: TeleportInfo
+    ) -> None:
+        """
+        Localize data found in `data_path` into the a local table with the name given by `relation`.
+        Handle each possible format defined in `storage_formats` method.
+        """
+        raise NotImplementedException(
+            "`teleport_from_external_storage` is not implemented for this adapter!"
+        )
+
+    @abc.abstractmethod
+    def teleport_to_external_storage(self, relation: BaseRelation, teleport_info: TeleportInfo) -> str:
+        """
+        Take local table `relation` and upload the data with Teleport. Return the `data_path` the data is uploaded to.
+        Handle each possible format defined in `storage_formats` method.
+        """
+        raise NotImplementedException(
+            "`teleport_to_external_storage` is not implemented for this adapter!"
+        )

--- a/core/dbt/adapters/teleport/impl.py
+++ b/core/dbt/adapters/teleport/impl.py
@@ -33,8 +33,6 @@ class TeleportAdapter:
 
     """
 
-    wrapper: Optional["TeleportAdapter"]
-
     @classmethod
     @abc.abstractmethod
     def storage_formats(cls) -> List[str]:

--- a/core/dbt/context/providers.py
+++ b/core/dbt/context/providers.py
@@ -1378,7 +1378,7 @@ class ModelContext(ProviderContext):
             from dbt.adapters.base.relation import BaseRelation
             from dbt.adapters.teleport import TeleportAdapter
 
-        from dbt.teleport import teleport_adapter_or_wrapper, build_teleport_info
+        from dbt.teleport import build_teleport_info, is_teleport_adapter
 
         target_adapter: TeleportAdapter = self.adapter  # type: ignore
 
@@ -1394,7 +1394,10 @@ class ModelContext(ProviderContext):
             )  # type: ignore
 
             # adapter of the ref being processed
-            ref_adapter = teleport_adapter_or_wrapper(target_adapter, get_adapter(self.config, node.language))
+            ref_adapter: TeleportAdapter = get_adapter(self.config, node.language)  # type: ignore
+
+            if not is_teleport_adapter(ref_adapter):
+                raise NotImplementedError(f"Teleport not implemented for adapter {ref_adapter.type()}")
 
             if target_adapter == ref_adapter:
                 # Do not process for same adapter

--- a/core/dbt/teleport/__init__.py
+++ b/core/dbt/teleport/__init__.py
@@ -1,2 +1,2 @@
-from .utils import is_teleport_adapter, teleport_adapter_or_wrapper, build_teleport_info  # noqa
+from .utils import is_teleport_adapter, build_teleport_info  # noqa
 from .teleport_info import TeleportInfo, S3TeleportInfo, LocalTeleportInfo  # noqa

--- a/core/dbt/teleport/__init__.py
+++ b/core/dbt/teleport/__init__.py
@@ -1,0 +1,2 @@
+from .utils import is_teleport_adapter, teleport_adapter_or_wrapper, build_teleport_info  # noqa
+from .teleport_info import TeleportInfo, S3TeleportInfo, LocalTeleportInfo  # noqa

--- a/core/dbt/teleport/teleport_info.py
+++ b/core/dbt/teleport/teleport_info.py
@@ -1,0 +1,85 @@
+from dataclasses import dataclass
+from typing import Union
+
+from dbt.adapters.base.relation import BaseRelation
+from dbt.contracts.relation import ComponentName
+
+@dataclass
+class TeleportInfo:
+    format: str
+
+    @classmethod
+    def relation_name(cls, relation: Union[str, BaseRelation]):
+        if isinstance(relation, str):
+            # TODO: should we check for quoting?
+            return relation
+        else:
+            path = relation.path
+            db = path.get_lowered_part(ComponentName.Database)
+            sc = path.get_lowered_part(ComponentName.Schema)
+            tb = path.get_lowered_part(ComponentName.Identifier)
+            return f"{db}.{sc}.{tb}"
+
+    def build_relation_path(self, relation: Union[str, BaseRelation]):
+        rel_name = TeleportInfo.relation_name(relation)
+        return rel_name + "." + self.format
+
+    def build_relation_url(self, relation: Union[str, BaseRelation]):
+        return self.build_url(self.build_relation_path(relation))
+
+    def build_url(self, path: str) -> str:
+        raise NotImplemented
+
+@dataclass
+class LocalTeleportInfo(TeleportInfo):
+    def build_url(self, path: str):
+        from pathlib import Path
+
+        dir = Path.cwd() / 'teleport'
+        dir.mkdir(exist_ok=True)
+
+        return dir / path
+
+# TODO: How to do Teleport Configuration
+# Will each adapter have to implement a specific case for each teleport backend.
+# And how will we generalize these configurations?
+# Each adapter will have a specific `teleport` property?
+#       my_db:
+#         type: duckdb
+#         path: ./local_file.db
+#         teleport:
+#             type: s3
+#             bucket: my_bucket
+#             access_key_id: ...
+#             secret_access_key: ...
+# Or a central configuration will be shared accross all adapters?
+#       targets:
+#         - name: quack
+#           type: duckdb
+#           path: ./local_file.db
+#         - name: pyfal
+#           type: fal
+#           mode: local
+#       envs:
+#         - name: dev
+#           targets:
+#             - quack
+#             - pyfal
+#           default: quack
+#           teleport: # sharing these to `quack` and `pyfal` targets
+#             type: s3
+#             bucket: my_bucket
+#             access_key_id: ...
+#             secret_access_key: ...
+#         - name: prod
+#           targets:
+#             ...
+# Hard to achieve for all different access methods Teleport backends can have.
+@dataclass
+class S3TeleportInfo(TeleportInfo):
+    bucket: str
+    inner_path: str = 'teleport/'
+    # access_key ?
+
+    def build_url(self, path: str):
+        return f's3://{self.bucket}/{self.inner_path}{path}'

--- a/core/dbt/teleport/utils.py
+++ b/core/dbt/teleport/utils.py
@@ -13,19 +13,6 @@ def is_teleport_adapter(adapter: Union[BaseAdapter, TeleportAdapter]) -> bool:
     ]
     return isinstance(adapter, TeleportAdapter) or all(map(lambda m: hasattr(adapter, m), methods))
 
-def teleport_adapter_or_wrapper(target_adapter: TeleportAdapter, ref_adapter: Union[BaseAdapter, TeleportAdapter]) -> TeleportAdapter:
-    """
-    Check if teleport method exists in ref or in wrapper and return accordingly
-    """
-
-    if is_teleport_adapter(ref_adapter):
-        return ref_adapter
-    elif hasattr(target_adapter, 'wrapper') and target_adapter.wrapper:
-        # TODO: info(f"Adapter {target_adapter.type()} taking over Teleport implementations of {ref_adapter.type()}")
-        return target_adapter.wrapper
-    else:
-        raise NotImplementedError(f"Teleport not implemented for adapter {ref_adapter.type()}")
-
 def find_format(target_adapter: TeleportAdapter, ref_adapter: TeleportAdapter):
     target_formats = target_adapter.storage_formats()
     ref_formats = ref_adapter.storage_formats()

--- a/core/dbt/teleport/utils.py
+++ b/core/dbt/teleport/utils.py
@@ -1,0 +1,45 @@
+from typing import Union
+
+from dbt.adapters.base.impl import BaseAdapter
+from dbt.adapters.teleport.impl import TeleportAdapter
+from dbt.config.runtime import RuntimeConfig
+from dbt.teleport.teleport_info import LocalTeleportInfo
+
+def is_teleport_adapter(adapter: Union[BaseAdapter, TeleportAdapter]) -> bool:
+    methods = [
+        "storage_formats",
+        "teleport_from_external_storage",
+        "teleport_to_external_storage",
+    ]
+    return isinstance(adapter, TeleportAdapter) or all(map(lambda m: hasattr(adapter, m), methods))
+
+def teleport_adapter_or_wrapper(target_adapter: TeleportAdapter, ref_adapter: Union[BaseAdapter, TeleportAdapter]) -> TeleportAdapter:
+    """
+    Check if teleport method exists in ref or in wrapper and return accordingly
+    """
+
+    if is_teleport_adapter(ref_adapter):
+        return ref_adapter
+    elif hasattr(target_adapter, 'wrapper') and target_adapter.wrapper:
+        # TODO: info(f"Adapter {target_adapter.type()} taking over Teleport implementations of {ref_adapter.type()}")
+        return target_adapter.wrapper
+    else:
+        raise NotImplementedError(f"Teleport not implemented for adapter {ref_adapter.type()}")
+
+def find_format(target_adapter: TeleportAdapter, ref_adapter: TeleportAdapter):
+    target_formats = target_adapter.storage_formats()
+    ref_formats = ref_adapter.storage_formats()
+    for format in target_formats:
+        if format in ref_formats:
+            return format
+
+    raise RuntimeError(
+        f"No common format between {target_adapter.type()} and {ref_adapter.type()} "
+        f"—  {ref_formats} | {target_formats}"
+    )
+
+def build_teleport_info(config: RuntimeConfig, target_adapter: TeleportAdapter, ref_adapter: TeleportAdapter):
+    teleport_format = find_format(target_adapter, ref_adapter)
+
+    # TODO: think of how to build other infos
+    return LocalTeleportInfo(teleport_format)


### PR DESCRIPTION
## TODO
- [ ] better documentation
- [ ] behavior with unrelated adapters (e.g. only-SQL bigquery)
- [ ] test with 2 teleport-implemented adapters